### PR TITLE
Improve distro-list handling

### DIFF
--- a/commands/distro_list/action/edit_distros_file.py
+++ b/commands/distro_list/action/edit_distros_file.py
@@ -1,0 +1,26 @@
+import re
+import warnings
+
+from common_utils.file_reader import read_csv_file
+from common_utils.file_writer import write_csv_file
+
+def fix_version(version_text):
+    return re.sub("^([0-9])", "v\g<1>", version_text)
+
+def edit_distros_list(file, distro_name, flags):
+    raw_file_info = read_csv_file(file)
+    flags = flags.split(",")
+
+    for i, entry in enumerate(raw_file_info):
+        page_name = entry["page_name"]
+        if not page_name:
+            warnings.warn(f"Line {i + 1} needs a page name.")
+            continue
+
+        if distro_name and not entry["distro_text"]:
+            entry["distro_text"] = distro_name
+
+        if "version-fix" in flags:
+            entry["version"] = fix_version(entry["version"])
+
+    write_csv_file(file,raw_file_info)

--- a/commands/distro_list/distro_list_handler.py
+++ b/commands/distro_list/distro_list_handler.py
@@ -1,5 +1,6 @@
 from .action.create_distros_file import create_trackdistro_file
 from .action.edit_distros_list import edit_distros_to_pagenames
+from .action.edit_distros_file import edit_distros_list
 from .utils import distro_file_reader as distro_file
 
 from .utils.distro_list_enums import Action
@@ -19,3 +20,7 @@ def handle_command(args):
         edit_distros_to_pagenames(pagename_to_distros, action = Action.DELETE)
     elif action == "create_file":
         create_trackdistro_file(args["wiikipage"], file)
+    elif action == "fix_file":
+        distro_text = args["distro-text"]
+        flags = args["fix-flags"]
+        edit_distros_list(file, distro_text, flags)

--- a/commands/distro_list/utils/distro_file_reader.py
+++ b/commands/distro_list/utils/distro_file_reader.py
@@ -1,42 +1,48 @@
-import os.path
-import csv
+import re
 import warnings
 from collections import defaultdict
 
 from commands.distro_list.utils import track_page_distros
+from mediawiki.mediawiki_read import read_text
+from common_utils.file_reader import read_csv_file
 
+def does_distro_need_version(distro_text):
+    parsed_text = read_text(distro_text)
+    if len(parsed_text.wikilinks) > 0:
+        return True
+    elif len(parsed_text.templates) > 0:
+        distro_template = parsed_text.templates[0]
+        assert(distro_template.name == "Distrib-ref")
+        return False
+    return True
 
-def parse_row(i, row):
-    if len(row) == 0:
-        warnings.warn("Line #{} is empty".format(i))
-        return None, None
-    elif len(row[0]) == 0:
-        warnings.warn("Line #{} contains an empty page name".format(i))
-        return None, None
-    elif len(row) == 1:
-        warnings.warn("Line #{} for pagename {} does not contain distro_list".format(i, row[0]))
-        return None, None
+def validate_distro_entry(update_entry, line_num):
+    page_name = update_entry["page_name"]
+    distro_text = update_entry["distro_text"]
+    version = update_entry["version"]
 
-    pagename = row[0]
-    distros = {}
+    if not page_name or not distro_text:
+        warnings.warn(f"entry on line {line_num} does NOT have a valid pagename or distro name")
+        return False
+    if does_distro_need_version(distro_text) and not version:
+        warnings.warn(f"entry on line {line_num} does NOT have a version")
+        return False
 
-    for distro_text in row[1:]:
-        distro_name = track_page_distros.read_distro_name(distro_text)
-        if distro_name is not None:
-            distros[distro_name] = distro_text
-    return pagename, distros
+    return True
 
 def read_distro_file(file):
-    if file is None or not os.path.exists(file):
-        raise RuntimeError("File {} does not exist.".format(file))
+    raw_file_info = read_csv_file(file)
 
     pages = defaultdict(lambda: dict())
+    for i, entry in enumerate(raw_file_info):
+        if not validate_distro_entry(entry, i+1):
+            continue
 
-    with open(file, newline='', encoding="utf8") as csvfile:
-        reader = csv.reader(csvfile, delimiter=",", quotechar="\"")
-        for i, row in enumerate(reader):
-            pagename, distros = parse_row(i, row)
-            if pagename is None:
-                continue
-            pages[pagename] |= distros
+        distro_text = entry["distro_text"]
+        distro_name = track_page_distros.read_distro_name(distro_text)
+        version = entry["version"]
+        if version:
+            distro_text = f"{distro_text} ({version})"
+
+        pages[entry["page_name"]] |= {distro_name: distro_text}
     return pages

--- a/commands/distro_list/utils/track_page_distros.py
+++ b/commands/distro_list/utils/track_page_distros.py
@@ -6,7 +6,7 @@ def fix_distro_custom_name(distro_name):
     if distro_name.startswith("The "):
         return distro_name[4:]
 
-    if distro_name.islower():
+    if distro_name.islower() or distro_name[0].isdigit():
         return distro_name
 
     for i in range(len(distro_name)):

--- a/commands/distro_list/utils/track_page_distros.py
+++ b/commands/distro_list/utils/track_page_distros.py
@@ -2,6 +2,19 @@ from mediawiki.mediawiki_read import *
 from mediawiki.mediawiki_parse import get_section_from_page, read_wikilink
 import warnings
 
+def fix_distro_custom_name(distro_name):
+    if distro_name.startswith("The "):
+        return distro_name[4:]
+
+    if distro_name.islower():
+        return distro_name
+
+    for i in range(len(distro_name)):
+        if distro_name[i].isupper():
+            return distro_name[i:]
+
+    return distro_name
+
 def read_distro_name(item):
     if str(item).strip() == "(none)":
         return None
@@ -15,7 +28,7 @@ def read_distro_name(item):
         assert(distro_template.name == "Distrib-ref")
         assert(len(distro_template.arguments) == 3)
         distro_name = distro_template.arguments[0].value
-    return distro_name
+    return fix_distro_custom_name(distro_name)
 
 def get_distros_from_section(section_text: WikiText):
     assert(len(section_text.get_lists()) == 1)

--- a/common_utils/file_writer.py
+++ b/common_utils/file_writer.py
@@ -1,0 +1,10 @@
+import csv
+
+def write_csv_file(file, csv_info):
+    if not file:
+        raise RuntimeError("File {} must be defined".format(file))
+
+    with open(file, "w", newline='', encoding="utf8") as f:
+        w = csv.DictWriter(f, csv_info[0].keys())
+        w.writeheader()
+        w.writerows(csv_info)

--- a/tests/test_commands/test_distro_list/test_utils/test_track_page_distros.py
+++ b/tests/test_commands/test_distro_list/test_utils/test_track_page_distros.py
@@ -6,6 +6,26 @@ import commands.distro_list.utils.track_page_distros as tpd
 import wikitextparser as wtp
 
 class TestTrackPageHandler(unittest.TestCase):
+    def test_fix_distro_custom_name(self):
+        orig_name = "Tarsa's Epic Track Pack"
+        new_name = tpd.fix_distro_custom_name(orig_name)
+        self.assertEqual(orig_name, new_name)
+
+    def test_fix_distro_custom_name_the(self):
+        orig_name = "The Tarsa's Epic Track Pack"
+        new_name = tpd.fix_distro_custom_name(orig_name)
+        self.assertEqual(new_name, "Tarsa's Epic Track Pack")
+
+    def test_fix_distro_custom_name_all_lower(self):
+        orig_name = "debut pack"
+        new_name = tpd.fix_distro_custom_name(orig_name)
+        self.assertEqual(orig_name, new_name)
+
+    def test_fix_distro_custom_name_all_upper_later(self):
+        orig_name = "debut Pack"
+        new_name = tpd.fix_distro_custom_name(orig_name)
+        self.assertEqual("Pack", new_name)
+
     def test_read_distro_name_wiikilink(self):
         actual_distro_name = "Distro Name"
         distro_text = f"[[{actual_distro_name}]]"

--- a/tests/test_commands/test_distro_list/test_utils/test_track_page_distros.py
+++ b/tests/test_commands/test_distro_list/test_utils/test_track_page_distros.py
@@ -26,6 +26,11 @@ class TestTrackPageHandler(unittest.TestCase):
         new_name = tpd.fix_distro_custom_name(orig_name)
         self.assertEqual("Pack", new_name)
 
+    def test_fix_distro_custom_name_number(self):
+        orig_name = "0 debut Pack"
+        new_name = tpd.fix_distro_custom_name(orig_name)
+        self.assertEqual(orig_name, new_name)
+
     def test_read_distro_name_wiikilink(self):
         actual_distro_name = "Distro Name"
         distro_text = f"[[{actual_distro_name}]]"


### PR DESCRIPTION
Distro list file now has headers and supports versions.
Primitive fix_file functionality to add distribution mediawiki text to all entries and add "v" to missing versions. 