### PR TITLE
Remove duplicate wbz-id updates based on ID and image

### DIFF
--- a/commands/miscinfo/action/edit_ids_on_page.py
+++ b/commands/miscinfo/action/edit_ids_on_page.py
@@ -1,3 +1,4 @@
+from common_utils.szslibrary_helpers import get_imagehash_by_id
 from common_utils.track_page_utils.template_utils import misc_info_utils
 from commands.miscinfo.utils import track_page_edit as track_edit
 from common_utils.file_reader import read_csv_file
@@ -6,6 +7,13 @@ from tockdomio import tockdomread, tockdomwrite
 def add_ids_to_page(page_id, page_text, new_arguments: dict, update_wbz=False):
     print(new_arguments)
     arguments = misc_info_utils.get_miscinfo_template(page_text)
+
+    image_id = arguments["image-id"] if arguments["image-id"] else arguments["wbz-id"]
+    existing_image_hash = get_imagehash_by_id(image_id)
+    if existing_image_hash == new_arguments["image_hash"]:
+        print(f"Existing image {image_id} is the same as incoming image {arguments[image_id]}, so skipping.")
+        return True
+
     track_edit.patch_ids_to_miscinfo_template(arguments, new_arguments, update_wbz)
     template_text = track_edit.create_miscinfo_template(arguments)
 

--- a/commands/miscinfo/action/edit_ids_on_page.py
+++ b/commands/miscinfo/action/edit_ids_on_page.py
@@ -4,14 +4,24 @@ from commands.miscinfo.utils import track_page_edit as track_edit
 from common_utils.file_reader import read_csv_file
 from tockdomio import tockdomread, tockdomwrite
 
+def is_image_update(arguments, new_image_hash):
+    # New tracks, which currently have no wbz-id, will need to be updated
+    if arguments["wbz-id"] is None:
+        return True
+
+    image_id = arguments["image-id"] if arguments["image-id"] else arguments["wbz-id"]
+    existing_image_hash = get_imagehash_by_id(image_id)
+    if existing_image_hash == new_image_hash:
+        print(f"{arguments['wbz-id']}: Existing image {image_id} is the same as incoming image, so skipping.")
+        return False
+
+    return True
+
 def add_ids_to_page(page_id, page_text, new_arguments: dict, update_wbz=False):
     print(new_arguments)
     arguments = misc_info_utils.get_miscinfo_template(page_text)
 
-    image_id = arguments["image-id"] if arguments["image-id"] else arguments["wbz-id"]
-    existing_image_hash = get_imagehash_by_id(image_id)
-    if existing_image_hash == new_arguments["image_hash"]:
-        print(f"Existing image {image_id} is the same as incoming image {arguments[image_id]}, so skipping.")
+    if not is_image_update(arguments, new_arguments["image_hash"]):
         return True
 
     track_edit.patch_ids_to_miscinfo_template(arguments, new_arguments, update_wbz)

--- a/commands/miscinfo/action/get_ids_from_szslibrary.py
+++ b/commands/miscinfo/action/get_ids_from_szslibrary.py
@@ -1,6 +1,40 @@
 from commands.miscinfo.utils.wbz_id_process import *
 from commands.miscinfo.utils.wbz_file_write import write_wbz_file
 
+
+def remove_unnecessary_entries(wbz_entries: list[WBZInfo]) -> list[WBZInfo]:
+    existing_image_ids = {}
+    for entry in wbz_entries:
+        #new tracks should ALWAYS be added to the file
+        is_new_track = entry.wbz_id == entry.image_id
+        if is_new_track:
+            existing_image_ids[entry.wbz_id] = entry
+            continue
+
+        #having no image OR being an alt version are grounds for NOT updating an image id
+        is_no_image = entry.image_hash is None
+        is_alt_version = entry.track_version_extra is not None
+        if is_no_image or is_alt_version:
+            warnings.warn(
+                f"{entry} is an update with no image ({is_no_image}) or is an alt version ({is_alt_version}), so skipping. Replace with {entry.image_hash} if needed.")
+            continue
+
+        if entry.wbz_id not in existing_image_ids:
+            existing_image_ids[entry.wbz_id] = entry
+            continue
+
+        existing_entry = existing_image_ids[entry.wbz_id]
+        if existing_entry.image_hash is None:
+            warnings.warn(f"{entry} is replacing entry with no image {existing_entry}.")
+            existing_image_ids[entry.wbz_id] = entry
+        elif existing_entry.image_hash == entry.image_hash:
+            warnings.warn(f"{entry} already has the image hash as {existing_entry}, so skipping.")
+        else:
+            warnings.warn(f"{entry} is replacing entry with image {existing_entry}. Replace with {existing_entry.image_hash} if needed.")
+            existing_image_ids[entry.wbz_id] = entry
+
+    return list(existing_image_ids.values())
+
 def get_wbz_ids(start_id, end_id, file_path):
     if not validate_start_end_wbz_ids(start_id, end_id):
         return False
@@ -10,8 +44,11 @@ def get_wbz_ids(start_id, end_id, file_path):
         wbz_info_entry = get_wbz_info(i)
         if wbz_info_entry is None:
             continue
-        wbz_info_entries.insert(0,wbz_info_entry)
+        wbz_info_entries.append(wbz_info_entry)
 
     write_wbz_file(file_path, wbz_info_entries)
+
+    wbz_info_entries = remove_unnecessary_entries(wbz_info_entries)
+    write_wbz_file(file_path + "_trimmed.csv", wbz_info_entries)
 
     return wbz_info_entries

--- a/commands/miscinfo/action/get_ids_from_szslibrary.py
+++ b/commands/miscinfo/action/get_ids_from_szslibrary.py
@@ -1,4 +1,3 @@
-from common_utils.szslibrary_helpers import validate_start_end_wbz_ids
 from commands.miscinfo.utils.wbz_id_process import *
 from commands.miscinfo.utils.wbz_file_write import write_wbz_file
 
@@ -9,8 +8,9 @@ def get_wbz_ids(start_id, end_id, file_path):
     wbz_info_entries = []
     for i in range(int(start_id), int(end_id) + 1):
         wbz_info_entry = get_wbz_info(i)
-        if wbz_info_entry:
-            wbz_info_entries.append(wbz_info_entry)
+        if wbz_info_entry is None:
+            continue
+        wbz_info_entries.insert(0,wbz_info_entry)
 
     write_wbz_file(file_path, wbz_info_entries)
 

--- a/commands/miscinfo/utils/wbz_id_process.py
+++ b/commands/miscinfo/utils/wbz_id_process.py
@@ -3,12 +3,13 @@ import warnings
 from common_utils.szslibrary_helpers import *
 
 class WBZInfo:
-    def __init__(self, page_id, track_name, track_version, wbz_id, image_id, image_hash):
+    def __init__(self, wbz_id, image_id, page_id, track_name, track_version, version_extra,  image_hash):
+        self.wbz_id = wbz_id
+        self.image_id = image_id
         self.page_id = page_id
         self.track_name = track_name
         self.track_version = track_version
-        self.wbz_id = wbz_id
-        self.image_id = image_id
+        self.track_version_extra = version_extra
         self.image_hash = image_hash
 
     def __repr__(self):
@@ -21,7 +22,8 @@ def get_wbz_info(wbz_id):
 
     page_id = track_info["track_wiki"]
     track_name = get_full_trackname(track_info)
-    track_version = get_full_versionname(track_info)
+    track_version = track_info["track_version"]
+    track_version_extra = track_info["track_version_extra"] if track_info["track_version_extra"] else None
     orig_wbz_id = track_info["track_family"]
     image_hash = get_imagehash_by_id(wbz_id)
 
@@ -32,4 +34,4 @@ def get_wbz_info(wbz_id):
         warnings.warn(f"wbz id {wbz_id} does NOT have an image, and is a new track. Writing 0 for image-id")
         wbz_id = 0
 
-    return WBZInfo(page_id, track_name, track_version, orig_wbz_id, wbz_id, image_hash)
+    return WBZInfo(orig_wbz_id, wbz_id, page_id, track_name, track_version, track_version_extra, image_hash)

--- a/commands/miscinfo/utils/wbz_id_process.py
+++ b/commands/miscinfo/utils/wbz_id_process.py
@@ -13,7 +13,10 @@ class WBZInfo:
         self.image_hash = image_hash
 
     def __repr__(self):
-        return f"{self.page_id}, {self.track_name}, {self.wbz_id}, {self.image_id}"
+        base_text = f"{self.wbz_id}/{self.image_id}: {self.track_name} {self.track_version}"
+        if self.track_version_extra:
+            base_text = f"{base_text}--{self.track_version_extra}"
+        return base_text
 
 def get_wbz_info(wbz_id):
     track_info = get_track_info(wbz_id)

--- a/commands/miscinfo/utils/wbz_id_process.py
+++ b/commands/miscinfo/utils/wbz_id_process.py
@@ -1,12 +1,15 @@
-from common_utils.szslibrary_helpers import get_track_info, get_full_versionname, get_full_trackname
+import warnings
+
+from common_utils.szslibrary_helpers import *
 
 class WBZInfo:
-    def __init__(self, page_id, track_name, track_version, wbz_id, image_id):
+    def __init__(self, page_id, track_name, track_version, wbz_id, image_id, image_hash):
         self.page_id = page_id
         self.track_name = track_name
         self.track_version = track_version
         self.wbz_id = wbz_id
         self.image_id = image_id
+        self.image_hash = image_hash
 
     def __repr__(self):
         return f"{self.page_id}, {self.track_name}, {self.wbz_id}, {self.image_id}"
@@ -20,5 +23,13 @@ def get_wbz_info(wbz_id):
     track_name = get_full_trackname(track_info)
     track_version = get_full_versionname(track_info)
     orig_wbz_id = track_info["track_family"]
+    image_hash = get_imagehash_by_id(wbz_id)
 
-    return WBZInfo(page_id, track_name, track_version, orig_wbz_id, wbz_id)
+    if image_hash is None and orig_wbz_id != wbz_id:
+        warnings.warn(f"wbz id {wbz_id} does NOT have an image, and it is an update. Skipping writing")
+        return None
+    elif image_hash is None:
+        warnings.warn(f"wbz id {wbz_id} does NOT have an image, and is a new track. Writing 0 for image-id")
+        wbz_id = 0
+
+    return WBZInfo(page_id, track_name, track_version, orig_wbz_id, wbz_id, image_hash)

--- a/common_utils/file_writer.py
+++ b/common_utils/file_writer.py
@@ -1,6 +1,9 @@
 import csv
 
 def write_csv_file(file, csv_info):
+    if not csv_info:
+        return
+
     if not isinstance(csv_info[0], dict):
         csv_info = [vars(entry) for entry in csv_info]
 

--- a/common_utils/szslibrary_helpers.py
+++ b/common_utils/szslibrary_helpers.py
@@ -1,4 +1,7 @@
+import hashlib
+
 from tockdomio import szslibrary_read
+from tockdomio.szslibrary_read import get_image_from_id
 
 
 def validate_wbz_id(id_text):
@@ -54,3 +57,10 @@ def get_full_trackname_version(track_info):
     track_name = get_full_trackname(track_info)
     version_name = get_full_versionname(track_info)
     return f"{track_name} {version_name}"
+
+def get_imagehash_by_id(image_id):
+    image_content = get_image_from_id(image_id)
+    if image_content is None:
+        return None
+
+    return hashlib.sha256(str(image_content).encode()).hexdigest()

--- a/tests/test_commands/test_miscinfo/test_action/test_edit_ids_on_page.py
+++ b/tests/test_commands/test_miscinfo/test_action/test_edit_ids_on_page.py
@@ -1,0 +1,39 @@
+import unittest
+from unittest import mock
+
+from commands.miscinfo.action import edit_ids_on_page as eiop
+
+class TestEditWbzIdsOnPage(unittest.TestCase):
+    @mock.patch("commands.miscinfo.action.edit_ids_on_page.get_imagehash_by_id")
+    def test_is_image_update(self, mock_get_imagehash_by_id):
+        mock_get_imagehash_by_id.return_value = "hash2"
+        arguments = {"wbz-id": 1, "image-id": None}
+        new_image_hash = "hash1"
+
+        is_image_update = eiop.is_image_update(arguments, new_image_hash)
+        self.assertTrue(is_image_update)
+        mock_get_imagehash_by_id.assert_called_once()
+
+    @mock.patch("commands.miscinfo.action.edit_ids_on_page.get_imagehash_by_id")
+    def test_is_image_same_hash(self, mock_get_imagehash_by_id):
+        mock_get_imagehash_by_id.return_value = "hash1"
+        arguments = {"wbz-id": 1, "image-id": 2}
+        new_image_hash = "hash1"
+
+        is_image_update = eiop.is_image_update(arguments, new_image_hash)
+        self.assertFalse(is_image_update)
+        mock_get_imagehash_by_id.assert_called_once()
+
+    @mock.patch("commands.miscinfo.action.edit_ids_on_page.get_imagehash_by_id")
+    def test_is_image_update_new_track(self, mock_get_imagehash_by_id):
+        mock_get_imagehash_by_id.return_value = "hash2"
+        arguments = {"wbz-id": None, "image-id": None}
+        new_image_hash = "hash1"
+
+        is_image_update = eiop.is_image_update(arguments, new_image_hash)
+        self.assertTrue(is_image_update)
+        mock_get_imagehash_by_id.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_commands/test_miscinfo/test_action/test_get_ids_from_szslibrary.py
+++ b/tests/test_commands/test_miscinfo/test_action/test_get_ids_from_szslibrary.py
@@ -1,0 +1,55 @@
+import unittest
+
+from commands.miscinfo.action import get_ids_from_szslibrary as gifs
+from commands.miscinfo.utils.wbz_id_process import WBZInfo
+
+
+class TestGetIdsFromSzslibrary(unittest.TestCase):
+    def setUp(self):
+        self.wbz_entries = []
+        self.wbz_entries.append(WBZInfo(1, 1, 1, "Track 1", "v1.0", None, "hash1"))
+        self.wbz_entries.append(WBZInfo(2, 4, 2, "Track 2", "v1.0", None,"hash2"))
+        self.wbz_entries.append(WBZInfo(3, 3, 3, "Track 3", "v1.0", None, None))
+
+    def test_remove_unnecessary_entries_all_keep(self):
+        actual_entries = gifs.remove_unnecessary_entries(self.wbz_entries)
+        self.assertListEqual(actual_entries, self.wbz_entries)
+
+    def test_remove_unnecessary_entries_remove_duplicate_update(self):
+        self.wbz_entries.append(WBZInfo(1, 4, 1, "Track 1", "v1.1", None, "hash1"))
+        actual_entries = gifs.remove_unnecessary_entries(self.wbz_entries)
+        self.assertEqual(len(actual_entries), 3)
+        wbz_id_1_entries = [e for e in actual_entries if e.wbz_id == 1]
+        self.assertEqual(len(wbz_id_1_entries), 1)
+        self.assertEqual(wbz_id_1_entries[0].image_id, 1)
+
+    def test_remove_unnecessary_entries_keep_image_update(self):
+        self.wbz_entries.append(WBZInfo(1, 4, 1, "Track 1", "v1.1", None, "hash4"))
+        actual_entries = gifs.remove_unnecessary_entries(self.wbz_entries)
+        self.assertEqual(len(actual_entries), 3)
+        wbz_id_1_entries = [e for e in actual_entries if e.wbz_id == 1]
+        self.assertEqual(len(wbz_id_1_entries), 1)
+        self.assertEqual(wbz_id_1_entries[0].image_id, 4)
+
+    def test_remove_unnecessary_entries_keep_latest_image(self):
+        self.wbz_entries.append(WBZInfo(1, 4, 1, "Track 1", "v1.1-alt", None, "hash1"))
+        self.wbz_entries.append(WBZInfo(1, 5, 1, "Track 1", "v1.2", None,"hash1"))
+        self.wbz_entries.append(WBZInfo(1, 6, 1, "Track 1", "v1.3", None,"hash1"))
+        self.wbz_entries.append(WBZInfo(1, 7, 1, "Track 1", "v1.4", None,"hash1"))
+        actual_entries = gifs.remove_unnecessary_entries(self.wbz_entries)
+        self.assertEqual(len(actual_entries), 3)
+        wbz_id_1_entries = [e for e in actual_entries if e.wbz_id == 1]
+        self.assertEqual(len(wbz_id_1_entries), 1)
+        self.assertEqual(wbz_id_1_entries[0].image_id, 1)
+
+    def test_remove_update_no_image(self):
+        self.wbz_entries.append(WBZInfo(1, 4, 1, "Track 1", "v1.1", None,None))
+        actual_entries = gifs.remove_unnecessary_entries(self.wbz_entries)
+        self.assertEqual(len(actual_entries), 3)
+        wbz_id_1_entries = [e for e in actual_entries if e.wbz_id == 1]
+        self.assertEqual(len(wbz_id_1_entries), 1)
+        self.assertEqual(wbz_id_1_entries[0].image_id, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_commands/test_miscinfo/test_action/test_get_ids_from_szslibrary.py
+++ b/tests/test_commands/test_miscinfo/test_action/test_get_ids_from_szslibrary.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 from commands.miscinfo.action import get_ids_from_szslibrary as gifs
 from commands.miscinfo.utils.wbz_id_process import WBZInfo
@@ -17,38 +18,42 @@ class TestGetIdsFromSzslibrary(unittest.TestCase):
 
     def test_remove_unnecessary_entries_remove_duplicate_update(self):
         self.wbz_entries.append(WBZInfo(1, 4, 1, "Track 1", "v1.1", None, "hash1"))
-        actual_entries = gifs.remove_unnecessary_entries(self.wbz_entries)
-        self.assertEqual(len(actual_entries), 3)
-        wbz_id_1_entries = [e for e in actual_entries if e.wbz_id == 1]
-        self.assertEqual(len(wbz_id_1_entries), 1)
-        self.assertEqual(wbz_id_1_entries[0].image_id, 1)
+        with warnings.catch_warnings(record=True) as w:
+            actual_entries = gifs.remove_unnecessary_entries(self.wbz_entries)
+            self.assertEqual(len(actual_entries), 3)
+            wbz_id_1_entries = [e for e in actual_entries if e.wbz_id == 1]
+            self.assertEqual(len(wbz_id_1_entries), 1)
+            self.assertEqual(wbz_id_1_entries[0].image_id, 1)
 
     def test_remove_unnecessary_entries_keep_image_update(self):
         self.wbz_entries.append(WBZInfo(1, 4, 1, "Track 1", "v1.1", None, "hash4"))
-        actual_entries = gifs.remove_unnecessary_entries(self.wbz_entries)
-        self.assertEqual(len(actual_entries), 3)
-        wbz_id_1_entries = [e for e in actual_entries if e.wbz_id == 1]
-        self.assertEqual(len(wbz_id_1_entries), 1)
-        self.assertEqual(wbz_id_1_entries[0].image_id, 4)
+        with warnings.catch_warnings(record=True) as w:
+            actual_entries = gifs.remove_unnecessary_entries(self.wbz_entries)
+            self.assertEqual(len(actual_entries), 3)
+            wbz_id_1_entries = [e for e in actual_entries if e.wbz_id == 1]
+            self.assertEqual(len(wbz_id_1_entries), 1)
+            self.assertEqual(wbz_id_1_entries[0].image_id, 4)
 
     def test_remove_unnecessary_entries_keep_latest_image(self):
         self.wbz_entries.append(WBZInfo(1, 4, 1, "Track 1", "v1.1-alt", None, "hash1"))
         self.wbz_entries.append(WBZInfo(1, 5, 1, "Track 1", "v1.2", None,"hash1"))
         self.wbz_entries.append(WBZInfo(1, 6, 1, "Track 1", "v1.3", None,"hash1"))
         self.wbz_entries.append(WBZInfo(1, 7, 1, "Track 1", "v1.4", None,"hash1"))
-        actual_entries = gifs.remove_unnecessary_entries(self.wbz_entries)
-        self.assertEqual(len(actual_entries), 3)
-        wbz_id_1_entries = [e for e in actual_entries if e.wbz_id == 1]
-        self.assertEqual(len(wbz_id_1_entries), 1)
-        self.assertEqual(wbz_id_1_entries[0].image_id, 1)
+        with warnings.catch_warnings(record=True) as w:
+            actual_entries = gifs.remove_unnecessary_entries(self.wbz_entries)
+            self.assertEqual(len(actual_entries), 3)
+            wbz_id_1_entries = [e for e in actual_entries if e.wbz_id == 1]
+            self.assertEqual(len(wbz_id_1_entries), 1)
+            self.assertEqual(wbz_id_1_entries[0].image_id, 1)
 
     def test_remove_update_no_image(self):
         self.wbz_entries.append(WBZInfo(1, 4, 1, "Track 1", "v1.1", None,None))
-        actual_entries = gifs.remove_unnecessary_entries(self.wbz_entries)
-        self.assertEqual(len(actual_entries), 3)
-        wbz_id_1_entries = [e for e in actual_entries if e.wbz_id == 1]
-        self.assertEqual(len(wbz_id_1_entries), 1)
-        self.assertEqual(wbz_id_1_entries[0].image_id, 1)
+        with warnings.catch_warnings(record=True) as w:
+            actual_entries = gifs.remove_unnecessary_entries(self.wbz_entries)
+            self.assertEqual(len(actual_entries), 3)
+            wbz_id_1_entries = [e for e in actual_entries if e.wbz_id == 1]
+            self.assertEqual(len(wbz_id_1_entries), 1)
+            self.assertEqual(wbz_id_1_entries[0].image_id, 1)
 
 
 if __name__ == '__main__':

--- a/tockdomio/szslibrary_read.py
+++ b/tockdomio/szslibrary_read.py
@@ -30,6 +30,8 @@ def get_image_from_id(image_id):
 
     try:
         response = requests.get(url, headers=headers)
+        if response.status_code == 404:
+            return None
         return response.raw
     except Exception as e:
         print(e)

--- a/tockdomio/szslibrary_read.py
+++ b/tockdomio/szslibrary_read.py
@@ -9,7 +9,8 @@ def do_szslibrary_query(base_params):
     try:
         response = requests.get(SZSLIBRARY_API, headers=headers, params=base_params)
         return response.json()
-    except:
+    except Exception as e:
+        print(e)
         return None
 
 
@@ -32,7 +33,7 @@ def get_image_from_id(image_id):
         response = requests.get(url, headers=headers)
         if response.status_code == 404:
             return None
-        return response.raw
+        return response.content
     except Exception as e:
         print(e)
         return None

--- a/tockdomio/szslibrary_read.py
+++ b/tockdomio/szslibrary_read.py
@@ -19,3 +19,18 @@ def get_by_wbz_id(wbz_id):
     }
 
     return do_szslibrary_query(base_params)
+
+def get_image_from_id(image_id):
+    image_id = str(image_id)
+    headers = {
+        'User-Agent': SZSLIBRARY_API_KEY,
+    }
+
+    url = f"{SZSLIBRARY_THUMBNAIL}{image_id[-2:]}/{image_id}.jpg"
+
+    try:
+        response = requests.get(url, headers=headers)
+        return response.raw
+    except Exception as e:
+        print(e)
+        return None


### PR DESCRIPTION
Automatically detect and remove wbz-id entries where an update is not necessary. This could be due to intermediate updates or duplicate image. 
Automatically detect cases where an image does not exist for a wbz-id
Prevent image-id updates to pages where not necessary. 