### PR TITLE
Handle SZSLibrary Responses with a Python Object

### DIFF
--- a/commands/miscinfo/utils/wbz_id_process.py
+++ b/commands/miscinfo/utils/wbz_id_process.py
@@ -1,7 +1,7 @@
 import warnings
 
 from common_utils.szslibrary_helpers import *
-from common_utils.szslibrary_helpers import get_track_info, get_full_versionname, get_full_trackname, get_mod_type
+from common_utils.szslibrary_helpers import get_track_info
 from common_utils.track_page_utils.wiiki_name_utils.track_disambiguation import get_page_from_name_authors
 
 class WBZInfo:

--- a/commands/miscinfo/utils/wbz_id_process.py
+++ b/commands/miscinfo/utils/wbz_id_process.py
@@ -29,32 +29,26 @@ def get_wbz_info(wbz_id):
     if not track_info:
         return None
 
-    print(track_info)
-
-    page_id = track_info["track_wiki"]
-    track_name = get_full_trackname(track_info)
-    track_version = get_full_versionname(track_info)
-    track_version_extra = track_info["track_version_extra"] if track_info["track_version_extra"] else None
-    orig_wbz_id = track_info["track_family"]
-    image_hash = get_imagehash_by_id(wbz_id)
-    track_authors = set(track_info["track_author"].split(","))
-    track_updaters = set() if track_info["track_editor"] is None else set(track_info["track_editor"].split(","))
+    track_name = track_info.get_full_trackname()
     find_manually = False
-
-    if not page_id:
-        disambig_track_name = get_page_from_name_authors(track_name, get_mod_type(track_info), track_authors)
+    if not track_info.id_first:
+        disambig_track_name = get_page_from_name_authors(track_info.get_full_trackname(), track_info.get_mod_type(), track_info.track_author)
         if disambig_track_name:
             track_name = disambig_track_name
         else:
             find_manually = True
         print(track_name)
 
-    if image_hash is None and orig_wbz_id != wbz_id:
+    image_hash = get_imagehash_by_id(wbz_id)
+    if image_hash is None and track_info.track_family != wbz_id:
         warnings.warn(f"wbz id {wbz_id} does NOT have an image, and it is an update. Skipping writing")
         return None
     elif image_hash is None:
         warnings.warn(f"wbz id {wbz_id} does NOT have an image, and is a new track. Writing 0 for image-id")
         wbz_id = 0
 
-    return WBZInfo(orig_wbz_id, wbz_id, page_id, track_name, track_version, track_version_extra, find_manually,
-                   image_hash, track_authors, track_updaters)
+    return WBZInfo(track_info.track_family, wbz_id,
+                   track_info.id_first, track_name,
+                   track_info.get_full_versionname(), track_info.track_version_extra, find_manually,
+                   image_hash,
+                   track_info.track_author, track_info.track_updaters)

--- a/commands/szslibrary/action/audit_category_entries.py
+++ b/commands/szslibrary/action/audit_category_entries.py
@@ -1,5 +1,5 @@
 from common_utils.base_category_action import BaseCategoryAction
-from common_utils.szslibrary_helpers import get_track_info
+from common_utils.szslibrary_helpers import get_track_info, SZSLibraryTrackInfo
 from common_utils.track_page_utils.template_utils import misc_info_utils
 from commands.szslibrary.utils.szslib_category_checker import *
 from constants import CATEGORY_CUSTOM, CATEGORY_EDIT, CATEGORY_TEXTURE

--- a/commands/szslibrary/utils/szslib_category_checker.py
+++ b/commands/szslibrary/utils/szslib_category_checker.py
@@ -1,4 +1,5 @@
 from commands.szslibrary.utils.audit_entry import AuditSzsLibraryEntry
+from common_utils.szslibrary_helpers import SZSLibraryTrackInfo
 from constants import CATEGORY_CUSTOM, SZSLIB_NINTENDO, SZSLIB_EDIT, SZSLIB_TEXTURE, SZSLIB_BATTLE, SZSLIB_TRACK, \
     CATEGORY_EDIT, CATEGORY_TEXTURE, SZSLIB_WBZID
 
@@ -24,19 +25,19 @@ def check_has_wbz_id(arguments, page_name):
     audit_entry.add_audit_info("wbz-id", "Empty", "Not Empty")
     return audit_entry
 
-def check_custom_status(track_status, track_info, page_name):
-    audit_entry = AuditSzsLibraryEntry(track_info[SZSLIB_WBZID], page_name)
-    is_nintendo = str(track_info[SZSLIB_NINTENDO]) == "1"
+def check_custom_status(track_status, track_info: SZSLibraryTrackInfo, page_name):
+    audit_entry = AuditSzsLibraryEntry(track_info.id_first, page_name)
+    is_nintendo = track_info.track_nintendo
     if track_status == CATEGORY_CUSTOM and is_nintendo:
         audit_entry.set_should_be_false(SZSLIB_NINTENDO)
     elif track_status != CATEGORY_CUSTOM and not is_nintendo:
         audit_entry.set_should_be_true(SZSLIB_NINTENDO)
     return audit_entry.get_if_has_audit_info()
 
-def check_track_modification(track_modification, track_info, page_name):
-    audit_entry = AuditSzsLibraryEntry(track_info[SZSLIB_WBZID], page_name)
-    is_edit = str(track_info[SZSLIB_EDIT]) == "1"
-    is_texture = str(track_info[SZSLIB_TEXTURE]) == "1"
+def check_track_modification(track_modification, track_info: SZSLibraryTrackInfo, page_name):
+    audit_entry = AuditSzsLibraryEntry(track_info.id_first, page_name)
+    is_edit = track_info.track_change
+    is_texture = track_info.track_texturehack
     if not track_modification and is_edit:
         audit_entry.set_should_be_false(SZSLIB_EDIT)
     elif not track_modification and is_texture:

--- a/commands/szslibrary/utils/szslib_entry_checker.py
+++ b/commands/szslibrary/utils/szslib_entry_checker.py
@@ -1,31 +1,18 @@
 import re
 
-from common_utils.szslibrary_helpers import get_track_info, get_full_trackname_version
+from common_utils.szslibrary_helpers import get_track_info, SZSLibraryTrackInfo
 from commands.szslibrary.utils.audit_entry import AuditSzsLibraryEntry
 
-def get_track_name(track_info):
-    track_name = f"{track_info['trackname']} {track_info['track_version']}".strip()
-    prefix = track_info['prefix']
-    if prefix:
-        track_name = f"{prefix} {track_name}"
-    version_extra = track_info['track_version_extra']
-    if version_extra:
-        track_name = f"{track_name}{version_extra}"
-    return track_name
-
-def check_track_wiki(wbz_id, track_name, track_info):
-    page_id = track_info["track_wiki"]
-    if not page_id:
+def check_track_wiki(wbz_id, track_name, track_info: SZSLibraryTrackInfo):
+    if not track_info.id_first:
         return AuditSzsLibraryEntry.create_no_pageid(wbz_id, track_name)
     return None
 
-def check_version_extra(wbz_id, track_name, track_info):
-    track_version_extra = track_info['track_version_extra']
-    if track_version_extra:
+def check_version_extra(wbz_id, track_name, track_info: SZSLibraryTrackInfo):
+    if track_info.track_version_extra:
         return None
 
-    track_version = track_info['track_version']
-    extra_regex = re.search("[0-9]([-.][a-zA-Z]{2,})$", track_version)
+    extra_regex = re.search("[0-9]([-.][a-zA-Z]{2,})$", track_info.track_version)
     if not extra_regex or not extra_regex.group(1):
         return None
 
@@ -41,7 +28,7 @@ def check_szslib_entry(wbz_id):
     print(track_info)
 
     audits = []
-    track_name = get_full_trackname_version(track_info)
+    track_name = track_info.get_full_trackname_version()
 
     for checker_function in checker_functions:
         audit = checker_function(wbz_id, track_name, track_info)

--- a/common_utils/szslibrary_helpers.py
+++ b/common_utils/szslibrary_helpers.py
@@ -112,40 +112,6 @@ def get_track_info(wbz_id):
 
     return SZSLibraryTrackInfo.from_szslibrary_response(szslibrary_response["track_info"])
 
-def get_mod_type(track_info):
-    if track_info[SZSLIB_EDIT] == 1:
-        return "Edit"
-    if track_info[SZSLIB_TEXTURE] == 1:
-        return "Texture"
-    return None
-
-def get_full_trackname(track_info):
-    track_name = f"{track_info['trackname']}".strip()
-    prefix = track_info['prefix']
-    if prefix:
-        track_name = f"{prefix} {track_name}"
-    return track_name
-
-def get_full_versionname(track_info):
-    version_name = f"{track_info['track_version']}".strip()
-    version_extra = track_info['track_version_extra']
-    if version_extra:
-        version_name = f"{version_name}-{version_extra}"
-    return version_name
-
-def get_full_trackname_version(track_info):
-    track_name = get_full_trackname(track_info)
-    version_name = get_full_versionname(track_info)
-    return f"{track_name} {version_name}"
-
-def get_full_disambiguation(track_info):
-    track_name = get_full_trackname(track_info)
-
-    track_authors = set(track_info["track_author"].split(","))
-    track_disambig = get_page_from_name_authors(track_name, track_authors)
-
-    return track_disambig
-
 def get_imagehash_by_id(image_id):
     image_content = get_image_from_id(image_id)
     if image_content is None:

--- a/common_utils/szslibrary_helpers.py
+++ b/common_utils/szslibrary_helpers.py
@@ -25,7 +25,7 @@ class SZSLibraryTrackInfo:
     track_music = ""
     track_speed = 1
     track_laps = 3
-    track_customtrack = 1
+    track_customtrack = 0
     track_customarena = 0
     track_texturehack = 0
     track_boost = 0
@@ -45,6 +45,13 @@ class SZSLibraryTrackInfo:
             track_info.track_updaters = set()
         else:
             track_info.track_updaters = set(track_info.track_editor.split(","))
+
+        track_info.track_customtrack = str(track_info.track_customtrack) == "1"
+        track_info.track_customarena = str(track_info.track_customarena) == "1"
+        track_info.track_texturehack = str(track_info.track_texturehack) == "1"
+        track_info.track_competition = str(track_info.track_competition) == "1"
+        track_info.track_nintendo = str(track_info.track_nintendo) == "1"
+        track_info.track_change = str(track_info.track_change) == "1"
 
         return track_info
 

--- a/common_utils/szslibrary_helpers.py
+++ b/common_utils/szslibrary_helpers.py
@@ -42,6 +42,32 @@ class SZSLibraryTrackInfo:
 
         return track_info
 
+    def get_mod_type(self):
+        if self.track_change:
+            return "Edit"
+        elif self.track_texturehack:
+            return "Texture"
+        return None
+
+    def get_full_trackname(self):
+        track_name = f"{self.trackname}".strip()
+        prefix = self.prefix
+        if prefix:
+            track_name = f"{prefix} {track_name}"
+        return track_name
+
+    def get_full_versionname(self):
+        version_name = f"{self.track_version}".strip()
+        version_extra = self.track_version_extra
+        if version_extra:
+            version_name = f"{version_name}-{version_extra}"
+        return version_name
+
+    def get_full_trackname_version(self):
+        track_name = self.get_full_trackname()
+        version_name = self.get_full_versionname()
+        return f"{track_name} {version_name}"
+
 def validate_wbz_id(id_text):
     if not id_text.isnumeric():
         return False

--- a/common_utils/szslibrary_helpers.py
+++ b/common_utils/szslibrary_helpers.py
@@ -5,6 +5,42 @@ import hashlib
 from tockdomio import szslibrary_read
 from tockdomio.szslibrary_read import get_image_from_id
 
+class SZSLibraryTrackInfo:
+    id_first = 0
+    track_wiki = 0
+    prefix = ""
+    trackname = ""
+    track_version = ""
+    track_version_extra = ""
+    track_author = ""
+    track_editor = ""
+    track_family = 0
+    track_clan = 0
+    track_sha1 = ""
+    track_created = ""
+    track_wbz_size = 0
+    track_warn = 0
+    track_slot = ""
+    track_prop = ""
+    track_music = ""
+    track_speed = 1
+    track_laps = 3
+    track_customtrack = 1
+    track_customarena = 0
+    track_texturehack = 0
+    track_boost = 0
+    track_competition = 0
+    track_nintendo = 0
+    track_change = 0
+
+    @classmethod
+    def from_szslibrary_response(cls, dict_response):
+        track_info = cls()
+        track_info.__dict__ = dict_response
+
+        track_info.track_author = set(track_info.track_author.split(","))
+
+        return track_info
 
 def validate_wbz_id(id_text):
     if not id_text.isnumeric():

--- a/common_utils/szslibrary_helpers.py
+++ b/common_utils/szslibrary_helpers.py
@@ -39,6 +39,12 @@ class SZSLibraryTrackInfo:
         track_info.__dict__ = dict_response
 
         track_info.track_author = set(track_info.track_author.split(","))
+        track_info.track_version_extra = track_info.track_version_extra or None
+
+        if track_info.track_editor is None or not track_info.track_editor.strip():
+            track_info.track_updaters = set()
+        else:
+            track_info.track_updaters = set(track_info.track_editor.split(","))
 
         return track_info
 
@@ -94,14 +100,10 @@ def validate_start_end_wbz_ids(start_id, end_id):
 
 def get_track_info(wbz_id):
     szslibrary_response = szslibrary_read.get_by_wbz_id(wbz_id)
-    if not szslibrary_response or not szslibrary_response["track_info"]:
+    if not szslibrary_response or not szslibrary_response.get("track_info", None):
         return None
 
-    track_info = szslibrary_response["track_info"]
-    if not track_info:
-        return None
-
-    return track_info
+    return SZSLibraryTrackInfo.from_szslibrary_response(szslibrary_response["track_info"])
 
 def get_mod_type(track_info):
     if track_info[SZSLIB_EDIT] == 1:

--- a/tests/test_commands/test_szslibrary/utils/test_szslib_category_checker.py
+++ b/tests/test_commands/test_szslibrary/utils/test_szslib_category_checker.py
@@ -2,6 +2,7 @@ import unittest
 
 from commands.szslibrary.utils import szslib_category_checker as scc
 from commands.szslibrary.utils.audit_entry import AuditSzsLibraryEntry
+from common_utils.szslibrary_helpers import SZSLibraryTrackInfo
 from constants import SZSLIB_NINTENDO, SZSLIB_WBZID, SZSLIB_EDIT, SZSLIB_TEXTURE
 
 
@@ -22,46 +23,46 @@ class TestSzsLibCategoryChecker(unittest.TestCase):
 
     def test_check_custom_status_custom_valid(self):
         track_status = "Custom"
-        track_info = {SZSLIB_WBZID: "1291239", SZSLIB_NINTENDO: "0"}
+        track_info = SZSLibraryTrackInfo.from_szslibrary_response({SZSLIB_WBZID: "1291239", SZSLIB_NINTENDO: "0"})
         audit_entry = scc.check_custom_status(track_status, track_info, self.page_name)
         self.assertIsNone(audit_entry)
 
     def test_check_custom_status_custom_invalid(self):
         track_status = "Custom"
-        track_info = {SZSLIB_WBZID: "1291239", SZSLIB_NINTENDO: "1"}
+        track_info = SZSLibraryTrackInfo.from_szslibrary_response({SZSLIB_WBZID: "1291239", SZSLIB_NINTENDO: "1"})
         audit_entry = scc.check_custom_status(track_status, track_info, self.page_name)
         self.assertIsInstance(audit_entry, AuditSzsLibraryEntry)
         self.assertEqual(audit_entry.faulty_column, SZSLIB_NINTENDO)
 
     def test_check_custom_status_nintendo_valid(self):
         track_status = ""
-        track_info = {SZSLIB_WBZID: "1291239", SZSLIB_NINTENDO: "1"}
+        track_info = SZSLibraryTrackInfo.from_szslibrary_response({SZSLIB_WBZID: "1291239", SZSLIB_NINTENDO: "1"})
         audit_entry = scc.check_custom_status(track_status, track_info, self.page_name)
         self.assertIsNone(audit_entry)
 
     def test_check_custom_status_nintendo_invalid(self):
         track_status = ""
-        track_info = {SZSLIB_WBZID: "1291239", SZSLIB_NINTENDO: "0"}
+        track_info = SZSLibraryTrackInfo.from_szslibrary_response({SZSLIB_WBZID: "1291239", SZSLIB_NINTENDO: "0"})
         audit_entry = scc.check_custom_status(track_status, track_info, self.page_name)
         self.assertIsInstance(audit_entry, AuditSzsLibraryEntry)
         self.assertEqual(audit_entry.faulty_column, SZSLIB_NINTENDO)
 
     def test_check_track_modification_none_valid(self):
         track_modification = ""
-        track_info = {SZSLIB_WBZID: "1291239", SZSLIB_EDIT: "0", SZSLIB_TEXTURE: "0"}
+        track_info = SZSLibraryTrackInfo.from_szslibrary_response({SZSLIB_WBZID: "1291239", SZSLIB_EDIT: "0", SZSLIB_TEXTURE: "0"})
         audit_entry = scc.check_track_modification(track_modification, track_info, self.page_name)
         self.assertIsNone(audit_entry)
 
     def test_check_track_modification_none_invalid_edit(self):
         track_modification = ""
-        track_info = {SZSLIB_WBZID: "1291239", SZSLIB_EDIT: "1", SZSLIB_TEXTURE: "0"}
+        track_info = SZSLibraryTrackInfo.from_szslibrary_response({SZSLIB_WBZID: "1291239", SZSLIB_EDIT: "1", SZSLIB_TEXTURE: "0"})
         audit_entry = scc.check_track_modification(track_modification, track_info, self.page_name)
         self.assertIsInstance(audit_entry, AuditSzsLibraryEntry)
         self.assertEqual(audit_entry.faulty_column, SZSLIB_EDIT)
 
     def test_check_track_modification_none_invalid_texture(self):
         track_modification = ""
-        track_info = {SZSLIB_WBZID: "1291239", SZSLIB_EDIT: "0", SZSLIB_TEXTURE: "1"}
+        track_info = SZSLibraryTrackInfo.from_szslibrary_response({SZSLIB_WBZID: "1291239", SZSLIB_EDIT: "0", SZSLIB_TEXTURE: "1"})
         audit_entry = scc.check_track_modification(track_modification, track_info, self.page_name)
         self.assertIsInstance(audit_entry, AuditSzsLibraryEntry)
         self.assertEqual(audit_entry.faulty_column, SZSLIB_TEXTURE)
@@ -69,13 +70,13 @@ class TestSzsLibCategoryChecker(unittest.TestCase):
 
     def test_check_track_modification_edit_valid_edit(self):
         track_modification = "Edit"
-        track_info = {SZSLIB_WBZID: "1291239", SZSLIB_EDIT: "1", SZSLIB_TEXTURE: "0"}
+        track_info = SZSLibraryTrackInfo.from_szslibrary_response({SZSLIB_WBZID: "1291239", SZSLIB_EDIT: "1", SZSLIB_TEXTURE: "0"})
         audit_entry = scc.check_track_modification(track_modification, track_info, self.page_name)
         self.assertIsNone(audit_entry)
 
     def test_check_track_modification_edit_invalid_none(self):
         track_modification = "Edit"
-        track_info = {SZSLIB_WBZID: "1291239", SZSLIB_EDIT: "0", SZSLIB_TEXTURE: "0"}
+        track_info = SZSLibraryTrackInfo.from_szslibrary_response({SZSLIB_WBZID: "1291239", SZSLIB_EDIT: "0", SZSLIB_TEXTURE: "0"})
         audit_entry = scc.check_track_modification(track_modification, track_info, self.page_name)
         self.assertIsInstance(audit_entry, AuditSzsLibraryEntry)
         self.assertEqual(audit_entry.faulty_column, SZSLIB_EDIT)
@@ -83,13 +84,13 @@ class TestSzsLibCategoryChecker(unittest.TestCase):
 
     def test_check_track_modification_texture_valid(self):
         track_modification = "Texture"
-        track_info = {SZSLIB_WBZID: "1291239", SZSLIB_EDIT: 0, SZSLIB_TEXTURE: 1}
+        track_info = SZSLibraryTrackInfo.from_szslibrary_response({SZSLIB_WBZID: "1291239", SZSLIB_EDIT: 0, SZSLIB_TEXTURE: 1})
         audit_entry = scc.check_track_modification(track_modification, track_info, self.page_name)
         self.assertIsNone(audit_entry)
 
     def test_check_track_modification_texture_invalid_none(self):
         track_modification = "Texture"
-        track_info = {SZSLIB_WBZID: "1291239", SZSLIB_EDIT: "0", SZSLIB_TEXTURE: "0"}
+        track_info = SZSLibraryTrackInfo.from_szslibrary_response({SZSLIB_WBZID: "1291239", SZSLIB_EDIT: "0", SZSLIB_TEXTURE: "0"})
         audit_entry = scc.check_track_modification(track_modification, track_info, self.page_name)
         self.assertIsInstance(audit_entry, AuditSzsLibraryEntry)
         self.assertEqual(audit_entry.faulty_column, SZSLIB_TEXTURE)
@@ -97,7 +98,7 @@ class TestSzsLibCategoryChecker(unittest.TestCase):
 
     def test_check_track_modification_texture_invalid_edit(self):
         track_modification = "Texture"
-        track_info = {SZSLIB_WBZID: "1291239", SZSLIB_EDIT: 1, SZSLIB_TEXTURE: 1}
+        track_info = SZSLibraryTrackInfo.from_szslibrary_response({SZSLIB_WBZID: "1291239", SZSLIB_EDIT: 1, SZSLIB_TEXTURE: 1})
         audit_entry = scc.check_track_modification(track_modification, track_info, self.page_name)
         self.assertIsInstance(audit_entry, AuditSzsLibraryEntry)
         self.assertEqual(audit_entry.faulty_column, SZSLIB_EDIT)

--- a/tests/test_commands/test_szslibrary/utils/test_szslib_entry_checker.py
+++ b/tests/test_commands/test_szslibrary/utils/test_szslib_entry_checker.py
@@ -1,19 +1,21 @@
 import unittest
 
 from commands.szslibrary.utils import szslib_entry_checker as sec
+from common_utils.szslibrary_helpers import SZSLibraryTrackInfo
+
 
 class TestSzslibEntryChecker(unittest.TestCase):
     def test_check_version_extra_valid(self):
         wbz_id = 129
         track_name = "Test Track"
-        track_info = {"track_version": "v1.1", "track_version_extra": ""}
+        track_info = SZSLibraryTrackInfo.from_szslibrary_response({"track_version": "v1.1", "track_version_extra": ""})
         audit_entry = sec.check_version_extra(wbz_id, track_name, track_info)
         self.assertIsNone(audit_entry)
 
     def test_check_version_extra_simpleversion(self):
         wbz_id = 129
         track_name = "Test Track"
-        track_info = {"track_version": "v1.1a", "track_version_extra": ""}
+        track_info = SZSLibraryTrackInfo.from_szslibrary_response({"track_version": "v1.1a", "track_version_extra": ""})
         audit_entry = sec.check_version_extra(wbz_id, track_name, track_info)
         self.assertIsNone(audit_entry)
 
@@ -21,7 +23,7 @@ class TestSzslibEntryChecker(unittest.TestCase):
     def test_check_version_extra_invalid(self):
         wbz_id = 129
         track_name = "Test Track"
-        track_info = {"track_version": "v1.1.ikw", "track_version_extra": ""}
+        track_info = SZSLibraryTrackInfo.from_szslibrary_response({"track_version": "v1.1.ikw", "track_version_extra": ""})
         audit_entry = sec.check_version_extra(wbz_id, track_name, track_info)
         self.assertIsNotNone(audit_entry)
         self.assertEqual(audit_entry.suggested_value, ".ikw")


### PR DESCRIPTION
Handle SZSLibrary responses using a Python object instead of a dict. This allows helper functions to be organized within the class and avoids annoying dict syntax. 